### PR TITLE
Bug fix in primitive recursion formula

### DIFF
--- a/src/math-log-questions.md
+++ b/src/math-log-questions.md
@@ -1386,7 +1386,7 @@ $z$-максимальный в M, если нет такого $t\in M: z\sqsub
         \left \{
           \begin{array}{ll}
             f(x_1,...,x_n), y=0\\
-            g(x_1, ..., x_n,y-1,R\langle f,g\rangle(x_1,...,x_n,y)), y>0
+            g(x_1, ..., x_n,y-1,R\langle f,g\rangle(x_1,...,x_n,y-1)), y>0
           \end{array}
         \right.
     $$


### PR DESCRIPTION
Bug fix in primitive recursion formula.  
`g(x1, x2, ..., x, y - 1, R<f, g>(x1, x2, ..., xn, y)) ->`  
`g(x1, x2, ..., x, y - 1, R<f, g>(x1, x2, ..., xn, y - 1))`